### PR TITLE
Update navigation_from_list_to_edit.md

### DIFF
--- a/070_routing/navigation_from_list_to_edit.md
+++ b/070_routing/navigation_from_list_to_edit.md
@@ -9,13 +9,15 @@ Add a new action `EditPlayer` in __src/Players/Actions.elm__
 ```elm
 ...
 
+import Hop
+
 type Action
   = NoOp
   | HopAction Hop.Action
   | EditPlayer PlayerId
 ```
 
-We will trigger this action when we intent to edit a player.
+We will trigger this action when we intend to edit a player.
 
 
 ## Players List
@@ -42,7 +44,7 @@ editBtn address player =
 
 Here we trigger `EditPlayer` with the id of the player that we want to edit. To do this we send the `EditPlayer` with the use id to the address.
 
-And change `playersRow` to include this button:
+And change `playerRow` to include this button:
 
 ```elm
 playerRow : Signal.Address Action -> ViewModel -> Player -> Html.Html
@@ -54,7 +56,7 @@ playerRow address model player =
     , td [] [ text (toString player.level) ]
     , td
         []
-        []
+        [editBtn address player]
     ]
 ```
 
@@ -63,11 +65,9 @@ playerRow address model player =
 Finally, __src/Players/Update.elm__ needs to respond to this action. Add a new branch to the case expression:
 
 ```elm
-...
-import Hop
-
-    ...
-
+update : Action -> UpdateModel -> ( List Player, Effects Action )
+update action model =
+  case action of
     EditPlayer id ->
       let
         path =
@@ -76,10 +76,15 @@ import Hop
         ( model.players, Effects.map HopAction (Hop.navigateTo path) )
 
     NoOp ->
-      ...
+      ( model.players, Effects.none )
+
+    HopAction _ ->
+      ( model.players, Effects.none )
 ```
 
 `Hop.navigateTo path` returns an effect. When this effect is run by Elm the location of the browser will change. You can read more about how this works [here](https://github.com/sporto/hop).
+
+Notice we also had to handle `HopAction` because we added it to **src/Players/Actions.elm**.
 
 ## Test it
 


### PR DESCRIPTION
- Fixed typo: _"intent"_ to _"intend".
- Fixed typo: `playersRow` to `playerRow`.
- Added `editBtn` in `playerRow` function.
- Add `import Hop` in **src/Players/Actions.elm** otherwise you'd see the following error:

```
-- NAMING ERROR -------------------------------------- ./src/Players/Actions.elm

Cannot find type `Hop.Action`.

9│   | HopAction Hop.Action
                 ^^^^^^^^^^
The qualifier `Hop` is not in scope. Maybe you want one of the following?

    Http.Action
```
- Fixed changes to **src/Players/Update.elm**. Handling `HopAction` is
  also required because it was added to **src/Players/Actions.elm**,
  otherwise you'd see the following error:

```
-- MISSING PATTERNS -----------------------------------
./src/Players/Update.elm

This `case` does not have branches for all possibilities.

14│>  case action of
15│>    EditPlayer id ->
16│>      let
17│>        path =
18│>          "/players/" ++ (toString id) ++ "/edit"
19│>      in
20│>        ( model.players, Effects.map HopAction (Hop.navigateTo path)
)
21│>
22│>    NoOp ->
23│>      ( model.players, Effects.none )

You need to account for the following values:

    Players.Actions.HopAction _

    Add a branch to cover this pattern!

    If you are seeing this error for the first time, check out these
    hints:
    <https://github.com/elm-lang/elm-compiler/blob/0.16.0/hints/missing-patterns.md>
    The recommendations about wildcard patterns and `Debug.crash` are
    important!
```
