### PR TITLE
Fix "route.signal" (should be Routing.signal)

### DIFF
--- a/070_routing/main.md
+++ b/070_routing/main.md
@@ -18,7 +18,7 @@ We need to map this signal to an action that our Main module can use. Add a func
 ```elm
 routerSignal : Signal Action
 routerSignal =
-  Signal.map RoutingAction router.signal
+  Signal.map RoutingAction Routing.signal
 ```
 
 This signal needs to be an input for StartApp. Change the `app` definition to:


### PR DESCRIPTION
In the tutorial, the text says "route.signal" where it should say "Routing.signal". The corresponding code in the example repository is correct.
