### PR TITLE
Add some commas and fix a typo in the Mailboxes 2 example

### DIFF
--- a/020_signals/mailboxes_2.md
+++ b/020_signals/mailboxes_2.md
@@ -73,10 +73,10 @@ Here is a diagram to help clarify what is happening:
 
 ![](mailbox-flow.png)
 
-- __(1)__ Initially `main` renders the view by passing the mailbox's address and the mailbox initial value (empty string)
-- __(2)__ When the view is rendered we set an event listener on the button by using `onClick`
-- __(3)__ When the button is clicked as message is sent to the mailbox's address
-- __(4)__ Upon receiving the message the mailbox emits a value on its signal which is picked up by main
+- __(1)__ Initially, `main` renders the view by passing the mailbox's address and the mailbox initial value (empty string)
+- __(2)__ When the view is rendered, we set an event listener on the button by using `onClick`
+- __(3)__ When the button is clicked, a message is sent to the mailbox's address
+- __(4)__ Upon receiving the message, the mailbox emits a value on its signal which is picked up by `main`
 - __(5)__ `main` then renders the view again by passing the mailbox's address and the message coming from the mailbox ("Hello")
 
 ### Conclusion


### PR DESCRIPTION
This PR adds some commas for clarity and fixes a typo in the Mailboxes 2 example.
