### PR TITLE
Fix dependencies for elm architecture startapp

### DIFF
--- a/030_elm_arch/startapp.md
+++ b/030_elm_arch/startapp.md
@@ -17,6 +17,7 @@ This pattern for organising an Elm application is referred as the __Elm architec
 Install start app by doing:
 
 ```bash
+elm package install evancz/elm-html
 elm package install evancz/start-app
 ```
 


### PR DESCRIPTION
 so that elm-html is explicitly specified

When making my way through the start app tutorial I found that the code provided wouldn't execute. This is because elm-html wasn't specified in the elm-package.json

This update asks the user to install elm-html as well as start-app when creating the app.
