### PR TITLE
Fix typo and remove extraneous namespacing

### DIFF
--- a/en/02-elm-arch/06-composing.md
+++ b/en/02-elm-arch/06-composing.md
@@ -46,7 +46,7 @@ view : Model -> Html Msg
 view model =
     div []
         [ div [] [ text (toString model.count) ]
-        , button [ onClick Increase ] [ Html.text "Click" ]
+        , button [ onClick Increase ] [ text "Click" ]
         ]
 
 

--- a/en/04-starting/03-webpack.md
+++ b/en/04-starting/03-webpack.md
@@ -14,8 +14,7 @@ There are many alternatives that you can use to achieve the same as Webpack, for
 
 ## Requirements
 
-Your will need Node JS version 4 or more for these libraries to work as expected.
-
+You will need Node JS version 4 or more for these libraries to work as expected.
 
 ## Installing webpack and loaders
 

--- a/en/07-routing/03-player-edit.md
+++ b/en/07-routing/03-player-edit.md
@@ -1,6 +1,6 @@
 # Player edit view
 
-We need a new view to show when hitting `/players/3`. 
+We need a new view to show when hitting `/players/3`.
 
 Create __src/Players/Edit.elm__:
 
@@ -13,7 +13,7 @@ import Players.Models exposing (..)
 import Players.Messages exposing (..)
 
 
-view : Player -> Html.Html Msg
+view : Player -> Html Msg
 view model =
     div []
         [ nav model
@@ -21,13 +21,13 @@ view model =
         ]
 
 
-nav : Player -> Html.Html Msg
+nav : Player -> Html Msg
 nav model =
     div [ class "clearfix mb2 white bg-black p1" ]
         []
 
 
-form : Player -> Html.Html Msg
+form : Player -> Html Msg
 form player =
     div [ class "m3" ]
         [ h1 [] [ text player.name ]
@@ -35,7 +35,7 @@ form player =
         ]
 
 
-formLevel : Player -> Html.Html Msg
+formLevel : Player -> Html Msg
 formLevel player =
     div
         [ class "clearfix py1"
@@ -49,13 +49,13 @@ formLevel player =
         ]
 
 
-btnLevelDecrease : Player -> Html.Html Msg
+btnLevelDecrease : Player -> Html Msg
 btnLevelDecrease player =
     a [ class "btn ml1 h1" ]
         [ i [ class "fa fa-minus-circle" ] [] ]
 
 
-btnLevelIncrease : Player -> Html.Html Msg
+btnLevelIncrease : Player -> Html Msg
 btnLevelIncrease player =
     a [ class "btn ml1 h1" ]
         [ i [ class "fa fa-plus-circle" ] [] ]

--- a/en/07-routing/08-navigation.md
+++ b/en/07-routing/08-navigation.md
@@ -31,7 +31,7 @@ import Html.Events exposing (onClick)
 Add a new function for this button at the end:
 
 ```elm
-editBtn : Player -> Html.Html Msg
+editBtn : Player -> Html Msg
 editBtn player =
     button
         [ class "btn regular"
@@ -83,7 +83,7 @@ Here we send the `ShowPlayers` when the button is clicked.
 And add this button to the list, change the `nav` function to:
 
 ```elm
-nav : Player -> Html.Html Msg
+nav : Player -> Html Msg
 nav model =
     div [ class "clearfix mb2 white bg-black p1" ]
         [ listBtn ]

--- a/en/08-edit/03-player-edit.md
+++ b/en/08-edit/03-player-edit.md
@@ -6,13 +6,13 @@ In __src/Players/Edit.elm__ change `btnLevelDecrease` and `btnLevelIncrease`:
 
 ```elm
 ...
-btnLevelDecrease : Player -> Html.Html Msg
+btnLevelDecrease : Player -> Html Msg
 btnLevelDecrease player =
     a [ class "btn ml1 h1", onClick (ChangeLevel player.id -1) ]
         [ i [ class "fa fa-minus-circle" ] [] ]
 
 
-btnLevelIncrease : Player -> Html.Html Msg
+btnLevelIncrease : Player -> Html Msg
 btnLevelIncrease player =
     a [ class "btn ml1 h1", onClick (ChangeLevel player.id 1) ]
         [ i [ class "fa fa-plus-circle" ] [] ]


### PR DESCRIPTION
Great tutorial! While reading I noticed one typo and some small inconsistencies with whether or not the `Html` namespacing was used when referring to functions, this cleans those up.
