### PR TITLE
Print error in case of fetch failure

### DIFF
--- a/en/03-subs-cmds/03-tasks.elm
+++ b/en/03-subs-cmds/03-tasks.elm
@@ -75,8 +75,8 @@ update msg model =
         FetchSuccess name ->
             ( name, Cmd.none )
 
-        FetchError _ ->
-            ( model, Cmd.none )
+        FetchError error ->
+            ( toString error, Cmd.none )
 
 
 


### PR DESCRIPTION
Hi,

i was going through the tutorial and in the example app for Tasks i had a typo in the api url(used "swapi.com" instead od "swapi.co"). And when i clicked the button nothing happend.

This way if someone has a similar problem it prints out the error message and he gets to know faster
