### PR TITLE
Webpack-3 -chapter code fixed to work with elm 0.18

### DIFF
--- a/en/04-starting/05-webpack-3.md
+++ b/en/04-starting/05-webpack-3.md
@@ -9,8 +9,7 @@ Create a basic Elm app. In __src/Main.elm__:
 ```elm
 module Main exposing (..)
 
-import Html exposing (Html, div, text)
-import Html.App
+import Html exposing (Html, div, text, program)
 
 
 -- MODEL
@@ -67,9 +66,9 @@ subscriptions model =
 -- MAIN
 
 
-main : Program Never
+main : Program Never Model Msg
 main =
-    Html.App.program
+    program
         { init = init
         , view = view
         , update = update


### PR DESCRIPTION
I noticed the example code in webpack-3 had not been adapted to elm 0.18 / elm-lang/html 2.0.0 like the preceding chapters had so I made the necessary changes.