### PR TITLE
Fix wrong player model field type in chapter 06-04

### DIFF
--- a/en/06-fetching-resources/04-players-cmds.md
+++ b/en/06-fetching-resources/04-players-cmds.md
@@ -36,6 +36,33 @@ memberDecoder =
         (field "name" Decode.string)
         (field "level" Decode.int)
 ```
+
+Also update __src/Players/Models.elm__ to match the types in the Json:
+
+```
+...
+type alias PlayerId = String
+...
+new : Player
+new =
+  { id = "0"
+  , name = ""
+  , level = 1
+  }
+```
+
+And __src/Players/List.elm__ to render the `player.id` correctly:
+
+```
+playerRow : Player -> Html Msg
+playerRow player =
+  tr []
+     [ td [] [ text player.id ]
+     , td [] [ text player.name ]
+     , td [] [ text (toString player.level) ]
+     , td [] []
+     ]
+```
 ---
 
 Let's go through this code.

--- a/en/06-fetching-resources/04-players-cmds.md
+++ b/en/06-fetching-resources/04-players-cmds.md
@@ -39,7 +39,7 @@ memberDecoder =
 
 Also update __src/Players/Models.elm__ to match the types in the Json:
 
-```
+```elm
 ...
 type alias PlayerId = String
 ...
@@ -53,7 +53,7 @@ new =
 
 And __src/Players/List.elm__ to render the `player.id` correctly:
 
-```
+```elm
 playerRow : Player -> Html Msg
 playerRow player =
   tr []


### PR DESCRIPTION
The Player model id field was defined as an integer in a previous chapter but the backend and the decoder both assume it is a string. I added the changes necessary to make the code compile.