### PR TITLE
Fixes typo in webpack 2 section

### DIFF
--- a/en-v01/04-starting/04-webpack-2.md
+++ b/en-v01/04-starting/04-webpack-2.md
@@ -45,7 +45,7 @@ var app = Elm.Main.embed(mountNode);
 Run:
 
 ```bash
-elm package install elm-lang/html
+elm-package install elm-lang/html
 ```
 
 After doing this there should be a file called __elm-package.json__ in the root of your project.

--- a/en/04-starting/04-webpack-2.md
+++ b/en/04-starting/04-webpack-2.md
@@ -45,7 +45,7 @@ var app = Elm.Main.embed(mountNode);
 Run:
 
 ```bash
-elm package install elm-lang/html
+elm-package install elm-lang/html
 ```
 
 After doing this there should be a file called __elm-package.json__ in the root of your project.

--- a/fr/04-commencer/04-webpack-2.md
+++ b/fr/04-commencer/04-webpack-2.md
@@ -44,7 +44,7 @@ var app = Elm.Main.embed(mountNode);
 Exécutez :
 
 ```bash
-elm package install elm-lang/html
+elm-package install elm-lang/html
 ```
 
 ## Répertoire source

--- a/jp/04-starting/04-webpack-2.md
+++ b/jp/04-starting/04-webpack-2.md
@@ -45,7 +45,7 @@ var app = Elm.Main.embed(mountNode);
 以下を実行します：
 
 ```bash
-elm package install elm-lang/html
+elm-package install elm-lang/html
 ```
 
 ## ソースディレクトリ

--- a/ko/04-starting/04-webpack-2.md
+++ b/ko/04-starting/04-webpack-2.md
@@ -45,7 +45,7 @@ var app = Elm.Main.embed(mountNode);
 터미널에서 아래 명령을 실행합니다:
 
 ```bash
-elm package install elm-lang/html
+elm-package install elm-lang/html
 ```
 
 ## 소스 디렉터리

--- a/zh-TW/04-starting/04-webpack-2.md
+++ b/zh-TW/04-starting/04-webpack-2.md
@@ -45,7 +45,7 @@ var app = Elm.Main.embed(mountNode);
 執行：
 
 ```bash
-elm package install elm-lang/html
+elm-package install elm-lang/html
 ```
 
 ## 程式碼目錄


### PR DESCRIPTION
'elm package' does not work for me, but elm-package is working. I supposed it was a simple typo.