### PR TITLE
Remove Unused Imports In Docs Example

### DIFF
--- a/en/04-starting/07-multiple-modules.md
+++ b/en/04-starting/07-multiple-modules.md
@@ -109,7 +109,7 @@ __src/Main.elm__
 ```elm
 module Main exposing (..)
 
-import Html exposing (Html, div, text, program)
+import Html exposing (program)
 import Msgs exposing (Msg)
 import Models exposing (Model)
 import Update exposing (update)


### PR DESCRIPTION
I think these imports are unused once your view code has moved to a separate module.

This brings this code in line with the file in the [example app](https://github.com/sporto/elm-tutorial-app/blob/018-v02-03-multiple-modules/src/Main.elm). Looks like they were dropped from there in [this commit](https://github.com/sporto/elm-tutorial-app/commit/4da99835c5f5314352ab5a542669c6dc0b49f15f).

Really enjoying the tutorial so far, thanks for writing it!