### PR TITLE
Fix Typo In Message Name

### DIFF
--- a/en/06-fetching-resources/05-update.md
+++ b/en/06-fetching-resources/05-update.md
@@ -2,7 +2,7 @@
 
 # Update
 
-When the request for players is done, we trigger the `OnFetchAll` message.
+When the request for players is done, we trigger the `OnFetchPlayers` message.
 
 __src/Update.elm__ should account for this new message. Change `update` to:
 


### PR DESCRIPTION
Think this was the name for the message in the [previous version](https://github.com/sporto/elm-tutorial/blob/master/en-v01/06-fetching-resources/03-players-update.md), and maybe got caught up in a copy-paste?

Still working through and enjoying the tutorial 🙂.