### PR TITLE
Fix the name/id of the Korean translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please open issues and send PRs at <https://github.com/sporto/elm-tutorial>.
 * French translation by Vincent Jousse [@vjousse](https://twitter.com/intent/user?screen_name=vjousse) and Augustin Ragon [@augustin82](https://twitter.com/intent/user?screen_name=augustin82).
 * Japanese translation by UEHARA Junji [@uehaj](https://twitter.com/intent/user?screen_name=uehaj).
 * 中文(繁體) translation by Jih-Chi Lee [@jihchi](https://github.com/jihchi).
-* Korean translation by Remi Gil [@remigil](https://github.com/remigil).
+* Korean translation by June Gil Seo [@junegil](https://github.com/junegil).
 
 ---
 


### PR DESCRIPTION
Hi @sporto Thanks for the great tutorial!

Found the Korean version of it and wonder who did the another great job and found the name is misspelled and the link is broken. So digged the PRs and found the right one.